### PR TITLE
update documentation about option parsing

### DIFF
--- a/gandi/cli/commands/docker.py
+++ b/gandi/cli/commands/docker.py
@@ -25,6 +25,9 @@ No docker vm specified. You can create one:
 
 Then configure it using:
     $ gandi docker --vm docker ps
+
+Or to both change target vm and spawn a process (note the -- separator):
+    $ gandi docker --vm myvm -- run -i -t debian bash
 """
         return
 

--- a/gandicli.man.rst
+++ b/gandicli.man.rst
@@ -155,7 +155,7 @@ Details:
 
 * ``gandi disk update resource`` modify the options of a virtual disk. Possible options are ``--name TEXT`` for the label of the virtual disk, ``--size INTEGER`` for the new size of the disk, ``--snapshotprofile TEXT`` to select a profile of snapshot to apply to the disk for keeping multiple version of data in a timeline. All these modification can be done as background process using the option ``--background`` (or ``--bg``).
 
-* ``gandi docker`` will setup ssh forwarding towards a gandi VM, remotely feeding a docker unix socket. This, for example, can be used for zeroconf access to scripted temporary build VMs. The ``--vm`` option alters the ``dockervm`` configuration parameter and can be used to set the VM used for future docker connections. ``dockervm`` can also be set locally for per-project vms (See ``gandi config``).
+* ``gandi docker`` will setup ssh forwarding towards a gandi VM, remotely feeding a docker unix socket. This, for example, can be used for zeroconf access to scripted temporary build VMs. The ``--vm`` option alters the ``dockervm`` configuration parameter and can be used to set the VM used for future docker connections. ``dockervm`` can also be set locally for per-project vms (See ``gandi config``). *NOTE*: passing option parameters to docker require the usage of the POSIX argument parsing ``--`` separator.
 
 * ``gandi domain create`` helps register a domain. Options are ``--domain domain.tld`` for the domain you want to get, ``--duration INTEGER RANGE`` for the registration period, ``--owner TEXT``, ``--admin TEXT``, ``--tech TEXTE``, ``--bill TEXT`` for the four contacts to pass to the creation process. All these modification can be done as background process using the option ``--background`` (or ``--bg``).
 


### PR DESCRIPTION
for docker subcommand, explicit usage of a -- separator
relates to issue #6 
