### PR TITLE
Add folders from the `gh-pages` orphan branch to the `.gitignore` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ gandi.1
 *.crt
 *.csr
 *.key
+
+# gh-pages
+node_modules/


### PR DESCRIPTION
so we don't get a dirty index when switching back from that branch to `master`.
