### PR TITLE
Update RPM specfile for 0.9 version

### DIFF
--- a/packages/gandicli.spec
+++ b/packages/gandicli.spec
@@ -1,24 +1,27 @@
 Name: gandicli
-Version: 0.1
+Version: 0.9
 Release: 1%{?dist}
 Summary: Gandi CLI as a service
 Group: System Management
 License: unknown
 URL: http://github.com/gandi/
-Source0: gandicli-%{version}.tgz
+Source0: gandicli-%{version}.tar.gz
 Provides: gandicli
-BuildRequires: python-docutils
-Requires: python >= 2.8, python-click, python-yaml
-BuildRoot: %{mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+BuildRequires: python-docutils, python2-devel
+Requires: python >= 2.7, python-click, python-yaml
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 
 %description
 administrate and deploy your gandi resources
 
 %prep
-tar xpzf %{sources}
+%setup -n gandi.cli-%{version}
 
 %build
-mkdir -p %{buildroot}
+%{__python2} setup.py build
+
+%install
+%{__python2} setup.py install --skip-build --root $RPM_BUILD_ROOT 
 rst2man --no-generator gandicli.man.rst | gzip -9 > gandi.1.gz
 install -d -m 0755 %{buildroot}/usr/share/man/man1
 install -m 0644 gandi.1.gz %{buildroot}/usr/share/man/man1
@@ -28,12 +31,12 @@ rm -r %{buildroot}
 
 %files
 %defattr(0755,root,root)
-/usr/bin/gandicli
+/usr/bin/gandi
 %defattr(0644,root,root)
 /usr/share/man/man1/gandi.1.gz
-/usr/lib/python2.7/dist-packages/gandi.cli-0.1-nspkg.pth
-/usr/lib/python2.7/dist-packages/gandi.cli-0.1.egg-info
-/usr/lib/python2.7/dist-packages/gandi.cli
+%{python2_sitelib}/*.egg-info
+%{python2_sitelib}/*-nspkg.pth
+%{python2_sitelib}/gandi/
 
 %changelog
 * Fri Jul 18 2014 Gandi <feedback@gandi.net> 0.1


### PR DESCRIPTION
- Use RPM macros
- Build python module using setuptools
- Reorganize %files section and dependencies
- Buildroot declaration compliant with Fedora/CentOS policy
