### PR TITLE
core: enhance kernel list

### DIFF
--- a/gandi/cli/core/params.py
+++ b/gandi/cli/core/params.py
@@ -119,7 +119,8 @@ class KernelParamType(GandiChoice):
 
     def _get_choices(self, gandi):
         """ Internal method to get choices list """
-        return [item['kernel_version'] for item in gandi.image.list()]
+        kernel_families = gandi.kernel.list(1).values()
+        return [kernel for klist in kernel_families for kernel in klist]
 
     def convert(self, value, param, ctx):
         """ Try to find correct kernel regarding version. """


### PR DESCRIPTION
we are currently basing kernel list on image.list()
some issues:
1. the list contains duplicates since we extract each kernel from all
   images
2. if the kernel is not included on an image, we will not be able to set
   it
   example:
   for grub, we currently don't have any image based on grub, so I had
   to insert an empty image with the grub kernel in order to make it
   work
3. we should check if the datacenter has the needed kernel before
setting it

this patch proposes to base the kernel list on the first datacenter
since for now, we may consider that all datacenter have the same
kernels.
This solution is not ideal but it avoids to insert an empty image with
the grub kernel which could confuse users.

A second patch should check the kernel depending on the disk's
datacenter.

Signed-off-by: William Dauchy william@gandi.net
