### PR TITLE
iaas: do not output API result when creating a VM in the background

### DIFF
--- a/gandi/cli/commands/vm.py
+++ b/gandi/cli/commands/vm.py
@@ -256,7 +256,8 @@ def create(gandi, datacenter, memory, cores, ip_version, bandwidth, login,
                                background,
                                sshkey, size, script)
     if background:
-        gandi.pretty_echo(result)
+        gandi.echo('* IAAS backend is now creating your VM and its '
+                   'associated resources in the background.')
 
     return result
 

--- a/gandi/cli/modules/iaas.py
+++ b/gandi/cli/modules/iaas.py
@@ -239,6 +239,8 @@ class Iaas(GandiModule, SshkeyHelper):
         cls.echo('* Configuration used: %d cores, %dMb memory, %s, '
                  'image %s, hostname: %s' % (cores, memory, ip_summary, image,
                                              hostname))
+
+        # background mode, bail out now (skip interactive part)
         if background:
             return result
 


### PR DESCRIPTION
`gandi vm create --background ...` pretty-prints the result of the
`hosting.vm.create_from` API call, which is a list of operations.
This is confusing to the user (it looks like the CLI is just spitting
a bunch of debugging output). I propose to display an informative
message instead. This makes the CLI nicer to use in automation
scripts.
