### PR TITLE
Improve domain create (remove --domain; print summary; prompt for confirmation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Set the VM's RAM to 2GB and add a CPU core on the fly.
 
 This command will setup the above VM, and install docker by running `curl -s https://get.docker.io/ubuntu | sh` after creation.
 
-#### 4. View your ressources
+#### 4. View your resources
 
     $ gandi vm list
 

--- a/gandi/cli/commands/domain.py
+++ b/gandi/cli/commands/domain.py
@@ -42,7 +42,7 @@ def info(gandi, resource):
 @click.option('--domain', default=None, prompt=True,
               callback=check_domain_available,
               help='Name of the domain.')
-@click.option('--duration', default=1, prompt=True,
+@click.option('--duration', default=1, 
               type=click.IntRange(min=1, max=10),
               help='Registration period in years, between 1 and 10.')
 @click.option('--owner', default=None,
@@ -58,6 +58,11 @@ def info(gandi, resource):
 @pass_gandi
 def create(gandi, domain, duration, owner, admin, tech, bill, background):
     """Buy a domain."""
+
+    # If domain is not available, no need to continue
+    if not domain:
+            return
+
     result = gandi.domain.create(domain, duration, owner, admin, tech, bill,
                                  background)
     if background:

--- a/gandi/cli/core/utils/__init__.py
+++ b/gandi/cli/core/utils/__init__.py
@@ -161,24 +161,30 @@ def check_domain_available(ctx, pointless_click_placeholder, domain):
     """ Helper to check if a domain is available."""
     # pointless_click_placeholder is to prevent Click compatibility warning
     gandi = ctx.obj
+    if domain is None:
+        domain = click.prompt("Enter the domain name you want to register")
+
     result = gandi.call('domain.available', [domain])
     while result[domain] == 'pending':
         time.sleep(1)
         result = gandi.call('domain.available', [domain])
 
     if result[domain] == 'unavailable':
-        gandi.echo('Sorry, the domain %s is not available for registration.' % domain)
-        return
+        gandi.echo("Sorry, the domain {d} is not available for registration. Try another?".format(d=domain))
+        return 
 
-    if result[domain] == 'available':
-        click.confirm('{d} is available, would you like to register it?'.format(d=domain), abort=True)
+    elif result[domain] == 'available':
+        # Prompt user for confirmation in next step
         return domain
 
-    if result[domain] == 'error_invalid':
+    elif result[domain] == 'error_invalid':
         gandi.echo("Sorry, {d} is not a valid domain.".format(d=domain))
+
+    # If we're here, it means we've received a result we haven't accounted for yet
     else:
         gandi.echo(result)
-        return
+
+    return
 
 
 def output_contact_info(gandi, data, output_keys, justify=10):

--- a/gandi/cli/core/utils/__init__.py
+++ b/gandi/cli/core/utils/__init__.py
@@ -156,9 +156,9 @@ def output_snapshot_profile(gandi, profile, output_keys, justify=13):
             gandi.separator_line()
             output_generic(gandi, schedule, schedule_keys, justify)
 
-
-def check_domain_available(ctx, domain):
+def check_domain_available(ctx, pointless_click_placeholder, domain):
     """ Helper to check if a domain is available."""
+    # pointless_click_placeholder is to prevent Click compatibility warning
     gandi = ctx.obj
     result = gandi.call('domain.available', [domain])
     while result[domain] == 'pending':
@@ -166,7 +166,7 @@ def check_domain_available(ctx, domain):
         result = gandi.call('domain.available', [domain])
 
     if result[domain] == 'unavailable':
-        gandi.echo('%s is not available' % domain)
+        gandi.echo('Sorry, the domain %s is not available for registration.' % domain)
         return
 
     return domain

--- a/gandi/cli/core/utils/__init__.py
+++ b/gandi/cli/core/utils/__init__.py
@@ -4,6 +4,7 @@ Also custom exceptions and method to generate a random string.
 """
 
 import time
+import click
 
 
 class MissingConfiguration(Exception):
@@ -169,7 +170,15 @@ def check_domain_available(ctx, pointless_click_placeholder, domain):
         gandi.echo('Sorry, the domain %s is not available for registration.' % domain)
         return
 
-    return domain
+    if result[domain] == 'available':
+        click.confirm('{d} is available, would you like to register it?'.format(d=domain), abort=True)
+        return domain
+
+    if result[domain] == 'error_invalid':
+        gandi.echo("Sorry, {d} is not a valid domain.".format(d=domain))
+    else:
+        gandi.echo(result)
+        return
 
 
 def output_contact_info(gandi, data, output_keys, justify=10):


### PR DESCRIPTION
Currently, `gandi domain create` requires the redundant `--domain` flag, e.g.:
`$ gandi domain create --domain example.com`

I have replaced `@click.option('--domain',...` with `@click.argument('domain',...` so that a domain name can be provided as a positional argument, e.g.:
`$ gandi domain create example.com` 

If the command is run without a domain name, the user is prompted to provide one interactively.

Also, the CLI will now display the contacts of the domain being registered, and prompt the user for confirmation before attempting to register the domain:

```
$ gandi domain create exampleawefafdsf.xyz
The domain exampleawefafdsf.xyz is available. If you continue, registration will be attempted 
with the following parameters:

        Duration: 1 year(s)
        Owner:    XX0000-GANDI
        Admin:    XX0000-GANDI
        Tech:     XX0000-GANDI
        Billing:  XX0000-GANDI

Your account will be charged. Do you want to continue? [y/N]:
```

If this is merged, we should probably add a `--yes` option so the prompt can be overridden.