### PR TITLE
Fix/py3 iaas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,7 @@ _build
 .settings
 
 # virtual env
-venv
+venv*
 
 conf/.pc
 api/.pc

--- a/gandi/cli/commands/certificate.py
+++ b/gandi/cli/commands/certificate.py
@@ -14,14 +14,13 @@ from gandi.cli.core.params import (pass_gandi, IntChoice,
 def packages(gandi):
     """ List certificate packages. """
     packages = gandi.certificate.package_list()
+    def keyfunc(item):
+        return (item['category']['id'],
+                item['max_domains'],
+                item['name'])
 
-    for package in sorted(packages,
-                          lambda a, b: cmp("%02d%03d%s" % (a['category']['id'],
-                                                           a['max_domains'],
-                                                           a['name']),
-                                           "%02d%03d%s" % (b['category']['id'],
-                                                           b['max_domains'],
-                                                           b['name']))):
+    packages.sort(key=keyfunc)
+    for package in packages:
         gandi.echo(package['name'])
 
     return packages

--- a/gandi/cli/core/base.py
+++ b/gandi/cli/core/base.py
@@ -160,12 +160,19 @@ class GandiModule(GandiConfig):
             return False
 
     @classmethod
-    def exec_output(cls, command, shell=True):
-        """ Return execution output """
+    def exec_output(cls, command, shell=True, encoding='utf-8'):
+        """ Return execution output
+
+        :param encoding: charset used to decode the stdout
+        :type encoding: str
+
+        :return: the return of the command
+        :rtype: unicode string
+        """
         proc = Popen(command, shell=shell, stdout=PIPE)
-        (stdout, _) = proc.communicate()
+        stdout, _stderr = proc.communicate()
         if proc.returncode == 0:
-            return stdout
+            return stdout.decode(encoding)
 
     @classmethod
     def update_progress(cls, progress, starttime):

--- a/gandi/cli/modules/iaas.py
+++ b/gandi/cli/modules/iaas.py
@@ -342,10 +342,10 @@ class Iaas(GandiModule, SshkeyHelper):
         we dont have another way to learn the key yet, so do this
         for the user."""
         cls.echo('Wiping old key and learning the new one')
-        version, ip_addr = cls.vm_ip(vm_id)
+        _version, ip_addr = cls.vm_ip(vm_id)
         cls.execute('ssh-keygen -R "%s"' % ip_addr)
 
-        for _ in xrange(5):
+        for _ in range(5):
             output = cls.exec_output('ssh-keyscan "%s"' % ip_addr)
             if output:
                 with open(os.path.expanduser('~/.ssh/known_hosts'), 'a') as f:
@@ -367,7 +367,7 @@ class Iaas(GandiModule, SshkeyHelper):
         cmd.extend((local_file, '%s@%s:%s' %
                    (login, ip_addr, remote_file),))
         cls.echo('Running %s' % ' '.join(cmd))
-        for _ in xrange(5):
+        for _ in range(5):
             ret = cls.execute(cmd, False)
             if ret:
                 break


### PR DESCRIPTION
Fix the following errors

```
Original contents retained as /home/guillaume/.ssh/known_hosts.old
Traceback (most recent call last):
  File "/home/guillaume/workspace/venv/gandi.cli-py3/bin/gandi", line 9, in <module>
    load_entry_point('gandi.cli==0.11', 'console_scripts', 'gandi')()
  File "/home/guillaume/workspace/git/gandi.cli/gandi/cli/__main__.py", line 8, in main
    cli(obj={})
  File "/home/guillaume/workspace/venv/gandi.cli-py3/lib/python3.4/site-packages/click-3.3-py3.4.egg/click/core.py", line 610, in __call__
    return self.main(*args, **kwargs)
  File "/home/guillaume/workspace/venv/gandi.cli-py3/lib/python3.4/site-packages/click-3.3-py3.4.egg/click/core.py", line 590, in main
    rv = self.invoke(ctx)
  File "/home/guillaume/workspace/git/gandi.cli/gandi/cli/core/cli.py", line 168, in invoke
    click.Group.invoke(self, ctx)
  File "/home/guillaume/workspace/venv/gandi.cli-py3/lib/python3.4/site-packages/click-3.3-py3.4.egg/click/core.py", line 936, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/guillaume/workspace/venv/gandi.cli-py3/lib/python3.4/site-packages/click-3.3-py3.4.egg/click/core.py", line 782, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/guillaume/workspace/venv/gandi.cli-py3/lib/python3.4/site-packages/click-3.3-py3.4.egg/click/core.py", line 416, in invoke
    return callback(*args, **kwargs)
  File "/home/guillaume/workspace/venv/gandi.cli-py3/lib/python3.4/site-packages/click-3.3-py3.4.egg/click/decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args[1:], **kwargs)
  File "/home/guillaume/workspace/venv/gandi.cli-py3/lib/python3.4/site-packages/click-3.3-py3.4.egg/click/core.py", line 416, in invoke
    return callback(*args, **kwargs)
  File "/home/guillaume/workspace/git/gandi.cli/gandi/cli/commands/vm.py", line 262, in create
    sshkey, size, script)
  File "/home/guillaume/workspace/git/gandi.cli/gandi/cli/modules/iaas.py", line 270, in create
    cls.ssh_keyscan(vm_id)
  File "/home/guillaume/workspace/git/gandi.cli/gandi/cli/modules/iaas.py", line 348, in ssh_keyscan
    for _ in xrange(5):
NameError: name 'xrange' is not defined


# 46.226.111.241 SSH-2.0-OpenSSH_6.6.1p1 Ubuntu-2ubuntu2
Traceback (most recent call last):
  File "/home/guillaume/workspace/venv/gandi.cli-py3/bin/gandi", line 9, in <module>
    load_entry_point('gandi.cli==0.11', 'console_scripts', 'gandi')()
  File "/home/guillaume/workspace/git/gandi.cli/gandi/cli/__main__.py", line 8, in main
    cli(obj={})
  File "/home/guillaume/workspace/venv/gandi.cli-py3/lib/python3.4/site-packages/click-3.3-py3.4.egg/click/core.py", line 610, in __call__
    return self.main(*args, **kwargs)
  File "/home/guillaume/workspace/venv/gandi.cli-py3/lib/python3.4/site-packages/click-3.3-py3.4.egg/click/core.py", line 590, in main
    rv = self.invoke(ctx)
  File "/home/guillaume/workspace/git/gandi.cli/gandi/cli/core/cli.py", line 168, in invoke
    click.Group.invoke(self, ctx)
  File "/home/guillaume/workspace/venv/gandi.cli-py3/lib/python3.4/site-packages/click-3.3-py3.4.egg/click/core.py", line 936, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/guillaume/workspace/venv/gandi.cli-py3/lib/python3.4/site-packages/click-3.3-py3.4.egg/click/core.py", line 782, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/guillaume/workspace/venv/gandi.cli-py3/lib/python3.4/site-packages/click-3.3-py3.4.egg/click/core.py", line 416, in invoke
    return callback(*args, **kwargs)
  File "/home/guillaume/workspace/venv/gandi.cli-py3/lib/python3.4/site-packages/click-3.3-py3.4.egg/click/decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args[1:], **kwargs)
  File "/home/guillaume/workspace/venv/gandi.cli-py3/lib/python3.4/site-packages/click-3.3-py3.4.egg/click/core.py", line 416, in invoke
    return callback(*args, **kwargs)
  File "/home/guillaume/workspace/git/gandi.cli/gandi/cli/commands/vm.py", line 262, in create
    sshkey, size, script)
  File "/home/guillaume/workspace/git/gandi.cli/gandi/cli/modules/iaas.py", line 270, in create
    cls.ssh_keyscan(vm_id)
  File "/home/guillaume/workspace/git/gandi.cli/gandi/cli/modules/iaas.py", line 352, in ssh_keyscan
    f.write(output)
TypeError: must be str, not bytes

```


Also fix python 3 certificate packages errors

```
$ gandi certificate packages   
Traceback (most recent call last):
  File "/home/guillaume/workspace/venv/gandi.cli-py3/bin/gandi", line 9, in <module>
    load_entry_point('gandi.cli==0.11', 'console_scripts', 'gandi')()
  File "/home/guillaume/workspace/git/gandi.cli/gandi/cli/__main__.py", line 8, in main
    cli(obj={})
  File "/home/guillaume/workspace/venv/gandi.cli-py3/lib/python3.4/site-packages/click-3.3-py3.4.egg/click/core.py", line 610, in __call__
    return self.main(*args, **kwargs)
  File "/home/guillaume/workspace/venv/gandi.cli-py3/lib/python3.4/site-packages/click-3.3-py3.4.egg/click/core.py", line 590, in main
    rv = self.invoke(ctx)
  File "/home/guillaume/workspace/git/gandi.cli/gandi/cli/core/cli.py", line 168, in invoke
    click.Group.invoke(self, ctx)
  File "/home/guillaume/workspace/venv/gandi.cli-py3/lib/python3.4/site-packages/click-3.3-py3.4.egg/click/core.py", line 936, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/guillaume/workspace/venv/gandi.cli-py3/lib/python3.4/site-packages/click-3.3-py3.4.egg/click/core.py", line 782, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/guillaume/workspace/venv/gandi.cli-py3/lib/python3.4/site-packages/click-3.3-py3.4.egg/click/core.py", line 416, in invoke
    return callback(*args, **kwargs)
  File "/home/guillaume/workspace/venv/gandi.cli-py3/lib/python3.4/site-packages/click-3.3-py3.4.egg/click/decorators.py", line 66, in new_func
    return ctx.invoke(f, obj, *args[1:], **kwargs)
  File "/home/guillaume/workspace/venv/gandi.cli-py3/lib/python3.4/site-packages/click-3.3-py3.4.egg/click/core.py", line 416, in invoke
    return callback(*args, **kwargs)
  File "/home/guillaume/workspace/git/gandi.cli/gandi/cli/commands/certificate.py", line 19, in packages
    lambda a, b: cmp("%02d%03d%s" % (a['category']['id'],
TypeError: must use keyword argument for key function

```