### PR TITLE
Missing dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,7 @@ gandi.1
 
 # gh-pages
 node_modules/
+
+# ArchLinux sources and binaries
+packages/archlinux/pkg/
+packages/archlinux/src/

--- a/README.md
+++ b/README.md
@@ -34,10 +34,14 @@ Use `$ gandi` to easily create and manage web resources from the command line.
 
 * A compatible operating system (Linux, BSD, Mac OS X/Darwin, Windows)
 * Python 2.6/2.7/3.2/3.3/3.4
+* openssl
+* openssh
+* git
 
 Recommended tools
 * [pip](https://pip.pypa.io/en/latest/installing.html)
 * [virtualenv](https://virtualenv.pypa.io/en/latest/installation.html)
+* docker
 
 ## Installation
 

--- a/packages/archlinux/PKGBUILD
+++ b/packages/archlinux/PKGBUILD
@@ -1,13 +1,13 @@
 # Maintainer: Raphaël Doursenaud <rdoursenaud@gpcsolutions.fr>
 pkgname=gandi.cli
 pkgver=0.12
-pkgrel=2
+pkgrel=3
 pkgdesc="Gandi command line interface"
 arch=('any')
 url="http://cli.gandi.net"
 license=('GPL3')
 groups=()
-depends=('python3' 'python-yaml' 'python-click' 'python-requests' 'python-ipy')
+depends=('python3' 'python-yaml' 'python-click' 'python-requests' 'python-ipy' 'openssl' 'openssh' 'git')
 optdepends=('docker: gandi docker support')
 makedepends=('python-docutils')
 provides=()

--- a/packages/archlinux/PKGBUILD
+++ b/packages/archlinux/PKGBUILD
@@ -8,6 +8,7 @@ url="http://cli.gandi.net"
 license=('GPL3')
 groups=()
 depends=('python3' 'python-yaml' 'python-click' 'python-requests' 'python-ipy')
+optdepends=('docker: gandi docker support')
 makedepends=('python-docutils')
 provides=()
 conflicts=()


### PR DESCRIPTION
AFAIK gandi.cli needs openssl, openssh and git to operate correctly.
docker seems optional.
I added these to the readme and updated my Arch Linux package accordingly.