### PR TITLE
add a special method invoke_with_exceptions

### DIFF
--- a/gandi/cli/tests/commands/base.py
+++ b/gandi/cli/tests/commands/base.py
@@ -27,3 +27,6 @@ class CommandTestCase(unittest.TestCase):
 
         for dummy in reversed(self.mocks):
             dummy.stop()
+
+    def invoke_with_exceptions(self, cli, args, catch_exceptions=False):
+        return self.runner.invoke(cli, args, catch_exceptions=catch_exceptions)

--- a/gandi/cli/tests/commands/test_certificate.py
+++ b/gandi/cli/tests/commands/test_certificate.py
@@ -7,8 +7,7 @@ class CertTestCase(CommandTestCase):
 
     def test_packages(self):
 
-        result = self.runner.invoke(certificate.packages, [],
-                                    catch_exceptions=False)
+        result = self.invoke_with_exceptions(certificate.packages, [])
 
         #self.assertEqual(result.exit_code, 0)
         wanted = (
@@ -42,8 +41,7 @@ Business Multi Domain  | cert_bus_20_250_0  | 20           | bus
 
     def test_list(self):
 
-        result = self.runner.invoke(certificate.list, [],
-                                    catch_exceptions=False)
+        result = self.invoke_with_exceptions(certificate.list, [])
 
         self.assertEqual(result.output, """cn           : mydomain.name
 plan         : Standard Single Domain
@@ -55,8 +53,7 @@ plan         : Business Multi Domain
 
     def test_info(self):
 
-        result = self.runner.invoke(certificate.info, ['inter.net'],
-                                    catch_exceptions=False)
+        result = self.invoke_with_exceptions(certificate.info, ['inter.net'])
 
         self.assertEqual(result.output, """cn           : inter.net
 date_created : 20140904T14:06:26
@@ -83,11 +80,11 @@ DG0VmOWZ0tWjyZuKgtoXgHnH3whEac+pM7M3J+z94/msO9hnpUOQNt4XALEoONrv
 v0L9Vc0443fop+UbFCabF0NWM6rJ31Nlv7s3mQIA
 -----END CERTIFICATE REQUEST-----'''
 
-        result = self.runner.invoke(certificate.create,
-                                    ['--csr', csr,
-                                     '--duration', 5,
-                                     '--max-altname', '5',
-                                     ], catch_exceptions=False)
+        result = self.invoke_with_exceptions(certificate.create,
+                                             ['--csr', csr,
+                                              '--duration', 5,
+                                              '--max-altname', '5',
+                                              ])
 
         wanted = '''The certificate create operation is 1
 You can follow it with:

--- a/gandi/cli/tests/commands/test_disk.py
+++ b/gandi/cli/tests/commands/test_disk.py
@@ -11,7 +11,7 @@ class DiskTestCase(CommandTestCase):
 
     def test_list(self):
 
-        result = self.runner.invoke(disk.list, [], catch_exceptions=False)
+        result = self.invoke_with_exceptions(disk.list, [])
 
         self.assertEqual(result.output, """name      : data
 state     : created
@@ -28,8 +28,7 @@ size      : 3072
         self.assertEqual(result.exit_code, 0)
 
     def test_info(self):
-        result = self.runner.invoke(disk.info, ['arch64'],
-                                    catch_exceptions=False)
+        result = self.invoke_with_exceptions(disk.info, ['arch64'])
 
         self.assertEqual(result.output, """name      : arch64
 state     : created
@@ -48,16 +47,14 @@ vm        : arch64
         self.assertRaises(ClickException, disk_check_size, None, None, 2040)
 
     def __test_detach(self):
-        result = self.runner.invoke(disk.detach, ['data'],
-                                    catch_exceptions=False)
+        result = self.invoke_with_exceptions(disk.detach, ['data'])
         self.assertEqual(result.output.strip(),
                          "Are you sure to detach data? [y/N]:"
                          )
         self.assertEqual(result.exit_code, 0)
 
     def test_detach_forced(self):
-        result = self.runner.invoke(disk.detach, ['-f', 'data'],
-                                    catch_exceptions=False)
+        result = self.invoke_with_exceptions(disk.detach, ['-f', 'data'])
         self.assertEqual(re.sub(r'\[#+\]', '[###]',
                                 result.output.strip()), """\
 The disk is still attached to the vm 80458.

--- a/gandi/cli/tests/commands/test_domain.py
+++ b/gandi/cli/tests/commands/test_domain.py
@@ -7,7 +7,7 @@ class DomainTestCase(CommandTestCase):
 
     def test_list(self):
 
-        result = self.runner.invoke(domain.list, [], catch_exceptions=False)
+        result = self.invoke_with_exceptions(domain.list, [])
 
         self.assertEqual(result.output, """iheartcli.com
 cli.sexy
@@ -15,8 +15,7 @@ cli.sexy
         self.assertEqual(result.exit_code, 0)
 
     def test_info(self):
-        result = self.runner.invoke(domain.info, ['iheartcli.com'],
-                                    catch_exceptions=False)
+        result = self.invoke_with_exceptions(domain.info, ['iheartcli.com'])
 
         self.assertEqual(result.output, """owner       : AA1-GANDI
 admin       : AA2-GANDI
@@ -32,14 +31,14 @@ tags        : bla
         self.assertEqual(result.exit_code, 0)
 
     def test_create(self):
-        result = self.runner.invoke(domain.create,
-                                    ['--domain', 'idontlike.website',
-                                     '--duration', 1,
-                                     '--owner', 'OWNER1-GANDI',
-                                     '--admin', 'ADMIN1-GANDI',
-                                     '--tech', 'TECH1-GANDI',
-                                     '--bill', 'BILL1-GANDI',
-                                     ], catch_exceptions=False)
+        result = self.invoke_with_exceptions(domain.create,
+                                             ['--domain', 'idontlike.website',
+                                              '--duration', 1,
+                                              '--owner', 'OWNER1-GANDI',
+                                              '--admin', 'ADMIN1-GANDI',
+                                              '--tech', 'TECH1-GANDI',
+                                              '--bill', 'BILL1-GANDI',
+                                              ])
 
         self.assertTrue('Your domain idontlike.website has been created'
                         in result.output)
@@ -47,11 +46,11 @@ tags        : bla
 
     def test_available_with_exception(self):
         self.assertRaises(DomainNotAvailable,
-                          self.runner.invoke, domain.create,
+                          self.invoke_with_exceptions, domain.create,
                           ['--domain', 'unavailable1.website',
                            '--duration', 1,
                            '--owner', 'OWNER1-GANDI',
                            '--admin', 'ADMIN1-GANDI',
                            '--tech', 'TECH1-GANDI',
                            '--bill', 'BILL1-GANDI',
-                           ], catch_exceptions=False)
+                           ])

--- a/gandi/cli/tests/commands/test_status.py
+++ b/gandi/cli/tests/commands/test_status.py
@@ -114,7 +114,7 @@ class StatusTestCase(CommandTestCase):
     def test_status(self):
         self._mock_http_request_working()
 
-        result = self.runner.invoke(root.status, [])
+        result = self.invoke_with_exceptions(root.status, [])
 
         wanted = ("""\
 IAAS      : All services are up and running
@@ -134,7 +134,7 @@ Email     : All services are up and running
     def test_status_service(self):
         self._mock_http_request_working()
 
-        result = self.runner.invoke(root.status, ['ssl'])
+        result = self.invoke_with_exceptions(root.status, ['ssl'])
 
         wanted = ("""\
 SSL       : All services are up and running
@@ -148,7 +148,7 @@ SSL       : All services are up and running
     def test_status_service_incident(self):
         self._mock_http_request_incident()
 
-        result = self.runner.invoke(root.status, ['paas'])
+        result = self.invoke_with_exceptions(root.status, ['paas'])
 
         url = 'https://status.gandi.net/timeline/events/7'
         wanted = ("""\


### PR DESCRIPTION
It's a wrapper around method 'invoke' to always send the
catch_exceptions=False for all tests