### PR TITLE
Transform config command into a namespace

### DIFF
--- a/gandi/cli/commands/config.py
+++ b/gandi/cli/commands/config.py
@@ -1,0 +1,79 @@
+""" Configuration namespace commands. """
+
+import sys
+import os
+import subprocess
+
+import click
+from click.exceptions import Abort
+
+from gandi.cli.core.cli import cli
+from gandi.cli.core.params import pass_gandi
+
+
+@cli.command()
+@click.option('-g', help='Get from global configuration only '
+                         '(default=env -> local -> global).',
+              is_flag=True, default=False)
+@click.argument('key')
+@pass_gandi
+def get(gandi, g, key):
+    """Display value of a given config key."""
+    val = gandi.get(key=key, global_=g)
+    if not val:
+        gandi.echo("No value found.")
+        sys.exit(1)
+    gandi.echo(val)
+
+
+@cli.command()
+@click.option('-g', help='Edit global configuration (default=local).',
+              is_flag=True, default=False)
+@click.argument('key')
+@click.argument('value')
+@pass_gandi
+def set(gandi, g, key, value):
+    """Update or create config key/value."""
+    gandi.configure(global_=g, key=key, val=value)
+
+
+@cli.command()
+@click.option('-g', help='Edit global configuration (default=local).',
+              is_flag=True, default=False)
+@pass_gandi
+def edit(gandi, g):
+    """Edit config file with prefered text editor"""
+    config_file = gandi.home_config if g else gandi.local_config
+    path = os.path.expanduser(config_file)
+    editor = gandi.get('editor')
+    if not editor:
+        try:
+            editor = click.prompt("Please enter the path of your prefered "
+                                  "editor. eg: '/usr/bin/vi' or 'vi'")
+        except Abort:
+            gandi.echo("""
+Warning: editor is not configured.
+You can use both 'gandi config set [-g] editor <value>'
+or the $EDITOR environment variable to configure it.""")
+            sys.exit(1)
+
+    subprocess.call([editor, path])
+
+
+@cli.command()
+@click.option('-g', help='Delete on global configuration (default=local).',
+              is_flag=True, default=False)
+@click.argument('key')
+@pass_gandi
+def delete(gandi, g, key):
+    """Delete a key/value pair from configuration"""
+    gandi.delete(global_=g, key=key)
+
+
+@cli.command()
+@click.option('-g', help='Display global configuration (default=local).',
+              is_flag=True, default=False)
+@pass_gandi
+def list(gandi, g):
+    """Display config file content"""
+    gandi.pretty_echo(gandi.list(global_=g))

--- a/gandi/cli/commands/paas.py
+++ b/gandi/cli/commands/paas.py
@@ -197,11 +197,11 @@ def create(gandi, name, size, type, quantity, duration, datacenter, vhosts,
     you can specify a configuration entry named 'sshkey' containing
     path to your sshkey file
 
-    $ gandi config -g sshkey ~/.ssh/id_rsa.pub
+    $ gandi config set [-g] sshkey ~/.ssh/id_rsa.pub
 
     or getting the sshkey "my_key" from your gandi ssh keyring
 
-    $ gandi config -g sshkey my_key
+    $ gandi config set [-g] sshkey my_key
 
     to know which PaaS instance type to use as type
 

--- a/gandi/cli/commands/root.py
+++ b/gandi/cli/commands/root.py
@@ -30,17 +30,6 @@ Setup completed. You can now:
 
 
 @cli.command()
-@click.option('-g', help='Edit global configuration (default=local).',
-              is_flag=True, default=False)
-@click.argument('key')
-@click.argument('value')
-@pass_gandi
-def config(gandi, g, key, value):
-    """Configure default values."""
-    gandi.configure(global_=g, key=key, val=value)
-
-
-@cli.command()
 @pass_gandi
 def api(gandi):
     """Display information about API used."""

--- a/gandi/cli/commands/vm.py
+++ b/gandi/cli/commands/vm.py
@@ -259,11 +259,11 @@ def create(gandi, datacenter, memory, cores, ip_version, bandwidth, login,
     you can specify a configuration entry named 'sshkey' containing
     path to your sshkey file
 
-    $ gandi config -g sshkey ~/.ssh/id_rsa.pub
+    $ gandi config set [-g] sshkey ~/.ssh/id_rsa.pub
 
     or getting the sshkey "my_key" from your gandi ssh keyring
 
-    $ gandi config -g sshkey my_key
+    $ gandi config set [-g] sshkey my_key
 
     to know which disk image label (or id) to use as image
 

--- a/gandi/cli/modules/docker.py
+++ b/gandi/cli/modules/docker.py
@@ -18,7 +18,7 @@ class Docker(GandiModule):
     Note that you can use a per-project docker vm by using
     a local directory gandi configuration using:
 
-    $ gandi config dockervm foobar
+    $ gandi config set dockervm foobar
 
     Or override the current global vm using:
 

--- a/gandi/cli/tests/commands/test_config.py
+++ b/gandi/cli/tests/commands/test_config.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+""" Configuration namespace tests. """
+
+import os
+
+from .base import CommandTestCase
+from gandi.cli.commands import config
+
+
+class ConfigTestCase(CommandTestCase):
+
+    def test_get_empty(self):
+        result = self.invoke_with_exceptions(config.get, [])
+        self.assertEqual(result.exit_code, 2)
+
+    def test_get_unknown(self):
+        result = self.invoke_with_exceptions(config.get, ['unknown-key'])
+        self.assertEqual(result.output, """No value found.
+""")
+        self.assertEqual(result.exit_code, 1)
+
+    def test_get(self):
+        result = self.invoke_with_exceptions(config.get, ['api'])
+        self.assertEqual(result.exit_code, 0)
+
+    def test_set_empty(self):
+        result = self.invoke_with_exceptions(config.set, [])
+        self.assertEqual(result.exit_code, 2)
+
+        result = self.invoke_with_exceptions(config.set, ['some-key'])
+        self.assertEqual(result.exit_code, 2)
+
+    def test_set_empty_value(self):
+        result = self.invoke_with_exceptions(config.set, ['some-key'])
+        self.assertEqual(result.exit_code, 2)
+
+    def test_set_get(self):
+        result = self.invoke_with_exceptions(config.set, ['dummy'])
+        self.assertEqual(result.exit_code, 2)
+
+        result = self.invoke_with_exceptions(config.set, ['dummy',
+                                                          'v4lu3'])
+        self.assertEqual(result.exit_code, 0)
+
+        result = self.invoke_with_exceptions(config.get, ['dummy'])
+        self.assertEqual(result.output, """v4lu3
+""")
+        self.assertEqual(result.exit_code, 0)
+
+    def test_delete_empty(self):
+        result = self.invoke_with_exceptions(config.set, [])
+        self.assertEqual(result.exit_code, 2)
+
+    def test_delete(self):
+        result = self.invoke_with_exceptions(config.set, ['dummy', 'value'])
+        self.assertEqual(result.exit_code, 0)
+
+        result = self.invoke_with_exceptions(config.get, ['dummy'])
+        self.assertEqual(result.output, """value
+""")
+        self.assertEqual(result.exit_code, 0)
+
+        result = self.invoke_with_exceptions(config.delete, ['dummy'])
+        self.assertEqual(result.exit_code, 0)
+
+        result = self.invoke_with_exceptions(config.get, ['unknown-key'])
+        self.assertEqual(result.output, """No value found.
+""")
+        self.assertEqual(result.exit_code, 1)
+
+    def test_edit(self):
+        os.environ['EDITOR'] = '/usr/bin/nano'
+        result = self.invoke_with_exceptions(config.get, ['editor'])
+        self.assertEqual(result.output, """/usr/bin/nano
+""")
+        self.assertEqual(result.exit_code, 0)
+
+        del os.environ['EDITOR']
+        result = self.invoke_with_exceptions(config.set, ['editor',
+                                                          '/usr/bin/vi'])
+        self.assertEqual(result.exit_code, 0)
+
+        result = self.invoke_with_exceptions(config.get, ['editor'])
+        self.assertEqual(result.output, """/usr/bin/vi
+""")
+        self.assertEqual(result.exit_code, 0)

--- a/gandi/cli/tests/commands/test_contact.py
+++ b/gandi/cli/tests/commands/test_contact.py
@@ -152,5 +152,7 @@ What is your production apikey: apikey0002
 Will save your apikey into the config file.""")
         self.assertEqual(result.exit_code, 0)
 
-        self.assertEqual(GandiModule._conffiles,
-                         {'global': {'api': {'key': 'apikey0002'}}})
+        self.assertTrue('api' in GandiModule._conffiles['global'])
+
+        api_key = GandiModule._conffiles['global']['api'].get('key')
+        self.assertEqual(api_key,'apikey0002')

--- a/gandicli.man.rst
+++ b/gandicli.man.rst
@@ -68,7 +68,11 @@ Namespaces:
 *  certstore delete        Delete an hosted certificate.
 *  certstore info          Display information about an hosted certificate.
 *  certstore list          List hosted certificates.
-*  config                  Configure default values.
+*  config delete           Delete a key/value pair from loaded configuration and save.
+*  config edit             Open configuration file in prefered editor.
+*  config get              Get value of a given key from loaded configuration.
+*  config list             List content of loaded configuration.
+*  config set              Set a key/value pair in loaded configuration and save.
 *  contact create          Create a new contact in interactive mode.
 *  datacenters             List available datacenters.
 *  deploy                  Deploy code on a remote vhost.


### PR DESCRIPTION
Configuration and defaults management made more flexible.
All `gandi config` commands accept the `-g` option to only
target the global configuration.

- [x] gandi config
  - [x] gandi config set ```<key> <value>``` [-g]
  - [x] gandi config get ```[<key>]``` [-g]
  - [x] gandi config delete ```<key>```  [-g]
  - [x] gandi config list  [-g]
  - [x] gandi config edit  [-g]

- [x] set a default value in configuration file only if the key is not present yet.

Fixes #149 and #54 