### PR TITLE
Invite user to buy credits in case of no-credits/no-hosting-account exception

### DIFF
--- a/gandi/cli/core/base.py
+++ b/gandi/cli/core/base.py
@@ -93,6 +93,12 @@ class GandiModule(GandiConfig):
         except APICallFailed as err:
             if kwargs.get('safe'):
                 return []
+            if err.code == 530040:
+                cls.echo("Error: It appears you haven't purchased any credits "
+                         "yet.\n"
+                         "Please visit https://www.gandi.net/credit/buy to "
+                         "learn more and buy credits.")
+                sys.exit(1)
             if err.code == 510150:
                 cls.echo("Invalid API key, please use 'gandi setup' command.")
                 sys.exit(1)


### PR DESCRIPTION
This PR simply catches the API error that is returned when attempting to query ressources that require credits.
The user is then invited to buy some credits : 

```
$ gandi disk create
Error: It appears you haven't purchased any credits yet.
Please visit https://www.gandi.net/credit/buy to learn more and buy credits.
```

Also known as the no hosting account exception:
```
Fault 530040: 'Error on object : OBJECT_HOSTING_ACCOUNT (CAUSE_DONTEXIST)
[no hosting account]
```