### PR TITLE
Exclude __pycache__ dirs & compiled files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,5 @@ include README.md
 include CHANGES.rst
 include LICENSE
 recursive-include gandi *
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]


### PR DESCRIPTION
The current release (0.18) source distribution (sdist) on PyPI contains
compiled sources (*.py[co]) and `__pycache__` directories.

This change adds recursive excludes to `MANIFEST.in` to preclude
inclusion of these in sdist generation.