### PR TITLE
Allow passing password as parameter for email creation

### DIFF
--- a/gandi/cli/commands/mail.py
+++ b/gandi/cli/commands/mail.py
@@ -41,20 +41,23 @@ def info(gandi, email):
               default=None)
 @click.option('--alias', '-a', help='Add mailbox alias.',
               multiple=True, required=False)
+@click.option('--password', '-p', default=None, type=click.STRING,
+              required=False, help='Prompt a password to create a mailbox.')
 @click.argument('email', type=EMAIL_TYPE, metavar='login@domain.tld')
 @pass_gandi
-def create(gandi, email, quota, fallback, alias):
+def create(gandi, email, quota, fallback, alias, password):
     """Create a mailbox."""
     login, domain = email
     options = {}
-    password = click.prompt('password', hide_input=True,
-                            confirmation_prompt=True)
+
+    if not password:
+        password = click.prompt('password', hide_input=True,
+                                confirmation_prompt=True)
     options['password'] = password
     if quota is not None:
         options['quota'] = quota
     if fallback is not None:
         options['fallback_email'] = fallback
-    options['password'] = password
 
     result = gandi.mail.create(domain, login, options, alias)
 

--- a/gandi/cli/tests/commands/test_mail.py
+++ b/gandi/cli/tests/commands/test_mail.py
@@ -49,6 +49,23 @@ Creating aliases.
         self.assertEqual(params['quota'], 2)
         self.assertEqual(params['fallback_email'], 'admin@cli.sexy')
 
+    def test_create_with_password(self):
+        args = ['contact2@iheartcli.com', '--quota', '2', '--fallback',
+                'admin@cli.sexy', '--alias', 'god@iheartcli.com',
+                '--password', 'password_for_create']
+        result = self.invoke_with_exceptions(mail.create, args,
+                                             obj=GandiContextHelper())
+
+        self.assertEqual(result.output, """Creating your mailbox.
+Creating aliases.
+""")
+
+        self.assertEqual(result.exit_code, 0)
+        params = self.api_calls['domain.mailbox.create'][0][2]
+        self.assertEqual(params['password'], 'password_for_create')
+        self.assertEqual(params['quota'], 2)
+        self.assertEqual(params['fallback_email'], 'admin@cli.sexy')
+
     def test_delete_force(self):
         args = ['admin@iheartcli.com', '--force']
         result = self.invoke_with_exceptions(mail.delete, args)

--- a/gandicli.man.rst
+++ b/gandicli.man.rst
@@ -258,7 +258,7 @@ Details:
 
 * ``gandi ip update`` update an ip. The only available parameter is now ``--reverse``, to specify a reverse (PTR record) name for this ip address.
 
-* ``gandi mail create login@domain.tld`` create a new mailbox. Possible options are ``-q, --quota INTEGER`` to define a quota for this mailbox, ``-f, --fallback TEXT`` to define a fallback addresse, ``-a, --alias TEXT`` to add an alias for this mailbox, this last option can be used multiple times.
+* ``gandi mail create login@domain.tld`` create a new mailbox. Possible options are ``-q, --quota INTEGER`` to define a quota for this mailbox, ``-f, --fallback TEXT`` to define a fallback addresse, ``-a, --alias TEXT`` to add an alias for this mailbox, this option can be used multiple times, ``-p, --password TEXT`` to provide a password for this mailbox.
 
 * ``gandi mail delete login@domain.tld`` delete mailbox ``login@domain.tld``. Possible option is ``--force`` (or ``-f``) to bypass the validation question; useful in non-interactive mode when scripting.
 


### PR DESCRIPTION
Allow passing password as parameter for email creation.

It's for issue #196