### PR TITLE
strip trailing "\n" from fetched certificates

### DIFF
--- a/gandi/cli/modules/cert.py
+++ b/gandi/cli/modules/cert.py
@@ -402,7 +402,7 @@ class Certificate(GandiModule):
         if crt:
             crt = ('-----BEGIN CERTIFICATE-----\n' +
                    '\n'.join([crt[index * 64:(index + 1) * 64]
-                              for index in range(int(len(crt) / 64) + 1)]) +
+                              for index in range(int(len(crt) / 64) + 1)]).rstrip('\n') +
                    '\n-----END CERTIFICATE-----')
         return crt
 


### PR DESCRIPTION
Hello,

Exporting a certificate with "gandi certificate export foo.bar" writes the certificate to a .crt file, but for some reason there is an extra line feed. (It gets fetched from your API like this). Ex : 

% cat foo.bar
------8<------ (snip)
NRwmxmjYC79sq661DopKIcJ6hY6UIsNmxCyoeWa2+cgdZagWPHTu5PnWJ062/Chq
QRwi4nwLedDYmLUhZ2M6IwbhFn/Jjd123453096qzug7Hu+8nioaJxH3vEyQBDdM
L/QPsQyh

-----END CERTIFICATE-----

This line feed duplicates with the one from '\n-----END CERTIFICATE-----'). Some software are confused with the extra linefeed. This is the simplest patch I came up with =)