### PR TITLE
vm: delete: Fix delete when we reach the list limit

### DIFF
--- a/gandi/cli/commands/vm.py
+++ b/gandi/cli/commands/vm.py
@@ -190,7 +190,7 @@ def delete(gandi, background, force, resource):
     stop_opers = []
     for item in resource:
         vm = next((vm for (index, vm) in enumerate(iaas_list)
-                  if vm['hostname'] == item), None)
+                   if vm['hostname'] == item), gandi.iaas.info(item))
         if vm['state'] == 'running':
             if background:
                 gandi.echo('Virtual machine not stopped, background option '


### PR DESCRIPTION
If we try to delete a vm that isn't present in the default limit of
gandi.iaas.list, the script fails.
Instead of falling back to none when iterating on the list, fallback to
gandi.iaas.info
The resource have already been checked so we know that we will have a right
object.

Signed-off-by: Emmanuel Vadot <emmanuel.vadot@gandi.net>