### PR TITLE
cert.get_dcv_params need cert_id

### DIFF
--- a/gandi/cli/commands/certificate.py
+++ b/gandi/cli/commands/certificate.py
@@ -469,7 +469,8 @@ def change_dcv(gandi, resource, dcv_method):
     csr = oper['params']['csr']
     package = cert['package']
     altnames = oper['params'].get('altnames')
-    gandi.certificate.advice_dcv_method(csr, package, altnames, dcv_method)
+    gandi.certificate.advice_dcv_method(csr, package, altnames, dcv_method,
+                                        cert_id=id_)
 
 
 @certificate.command('resend-dcv')

--- a/gandi/cli/modules/cert.py
+++ b/gandi/cli/modules/cert.py
@@ -233,9 +233,11 @@ class Certificate(GandiModule):
         return packages[0] if packages else None
 
     @classmethod
-    def advice_dcv_method(cls, csr, package, altnames, dcv_method):
+    def advice_dcv_method(cls, csr, package, altnames, dcv_method, cert_id=None):
         """ Display dcv_method information. """
         params = {'csr': csr, 'package': package, 'dcv_method': dcv_method}
+        if cert_id:
+            params['cert_id'] = cert_id
         result = cls.call('cert.get_dcv_params', params)
         if dcv_method == 'dns':
             cls.echo('You have to add these records in your domain zone :')
@@ -259,8 +261,6 @@ class Certificate(GandiModule):
             params['altnames'] = altnames
         if dcv_method:
             params['dcv_method'] = dcv_method
-            if dcv_method in ('dns', 'file'):
-                cls.advice_dcv_method(csr, package, altnames, dcv_method)
 
         try:
             result = cls.call('cert.create', params)
@@ -271,6 +271,9 @@ class Certificate(GandiModule):
             cls.error(msg)
             raise
 
+        if dcv_method in ('dns', 'file'):
+            cls.advice_dcv_method(csr, package, altnames, dcv_method,
+                                  cert_id=result['params'].get('cert_id'))
         return result
 
     @classmethod


### PR DESCRIPTION
 to correctly return the unique_value part of dcv record.