### PR TITLE
Password creation compliant with GANDI public API

### DIFF
--- a/gandi/cli/core/utils/password.py
+++ b/gandi/cli/core/utils/password.py
@@ -9,7 +9,7 @@ import string
 PUNCTUATION = string.punctuation.replace(chr(0x5c), '')
 
 
-def mkpassword(length=16, chars=None, punctuation=None):
+def mkpassword(length=16, chars=None, punctuation=1):
     """Generates a random ascii string - useful to generate authinfos
 
     :param length: string wanted length
@@ -40,5 +40,10 @@ def mkpassword(length=16, chars=None, punctuation=None):
         for _ in range(punctuation):
             data.append(random.choice(PUNCTUATION))
         random.shuffle(data)
+
+    # Mandatory digit
+    data = data[:-1]
+    data.append(random.choice(string.digits))
+    random.shuffle(data)
 
     return ''.join(data)


### PR DESCRIPTION
The GANDI public API has a more strict password validation since a couple of release. This change allow to be more compliant with the new validation. We have to be sure of the presence of one ponctuation item and a digit in the creation of the password.

Signed-off-by: aegiap <aegiap@gandi.net>