### PR TITLE
Add deprecation message about Gandi CLI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,13 @@
 # Contributing to the Gandi CLi
 
+> We have decided not to continue to maintain the CLI project. The existing project will remain as-is. Anyone interested in taking over and forking the project can let us know and we can inform our users and/or link to it.
+>
+> If you have any questions, please feel free to [contact our team](https://help.gandi.net/en/contact/feedback).
+>
+> Sincerely,
+>
+> The Gandi.net team
+
 ## Topics
 
 * [Reporting Issues](#reporting-issues)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,19 @@
 [![Pip Version](https://img.shields.io/pypi/v/gandi.cli.svg)](https://pypi.python.org/pypi/gandi.cli)
 [![Python Version](https://img.shields.io/pypi/pyversions/gandi.cli.svg)](https://pypi.python.org/pypi/gandi.cli)
 
+**⚠️ DEPRECATION notice**:
+> Hello,
+>
+> We have decided not to continue to maintain the CLI project. The existing project will remain as-is. Anyone interested in taking over and forking the project can let us know and we can inform our users and/or link to it.
+>
+> If you have any questions, please feel free to [contact our team](https://help.gandi.net/en/contact/feedback).
+>
+> Sincerely,
+>
+> The Gandi.net team
+
+<hr/>
+
 Use `$ gandi` to easily create and manage web resources from the command line.
 
 * `$ gandi domain` to buy and manage your domain names


### PR DESCRIPTION
As decided internally (T88051), in order to constantly deploy our efforts to maintain and push cool features to our current Gandi V5 platform, we decided to deprecate the current Gandi CLI.

The CLI is made to work with the previous version of Gandi V4 that most of our customers have created or migrated their account to the current version of the platform and are unable to generate Gandi V4 API keys.

Before we find what kind or resources (CLI, libs) we can propose to our customers in replacement to this project, we purpose at this time our [Gandi V5 REST API](https://api.gandi.net/docs/) and the Openstack API for our [GandiCloud VPS product](https://docs.gandi.net/en/cloud/vps/api/index.html).

**Note**: the Gandi V5 REST API is still marked as “beta”. We still continue to implement new services, new endpoints and a sandbox environment to our REST API service. Otherwise, for the current endpoints we already expose, we only do bug fixes and implement if needed new filters and parameters. If you use or plan to use the Gandi V5 API, we recommend you to take a look frequently our [changelog page](https://api.gandi.net/docs/changelog/) and the release notes that we publish frequently in our [blog](https://news.gandi.net/en/category/updates-and-releases).  

We leave the project as is for our customers that still have access to the V4 XML-RPC API. If someone wants to fork the project and want to maintain it, don't hesitate to manifest you.

In any case, if you need help or have questions, feel free to [contact us](https://help.gandi.net/fr/contact/feedback), we will be happy to help you and discuss with you!